### PR TITLE
Minor MLJ interface fix. Add MLJ interface test.

### DIFF
--- a/src/SelfOrganizingMaps.jl
+++ b/src/SelfOrganizingMaps.jl
@@ -66,7 +66,7 @@ MMI.fitted_params(m::SelfOrganizingMap, fitresult) = (weights=fitresult.W,)
 
 
 
-function MMI.transform(m, fitresult, X)
+function MMI.transform(m::SelfOrganizingMap, fitresult, X)
     som = fitresult
     Xmatrix = transpose(MMI.matrix(X))
 

--- a/src/SelfOrganizingMaps.jl
+++ b/src/SelfOrganizingMaps.jl
@@ -76,7 +76,6 @@ function MMI.transform(m::SelfOrganizingMap, fitresult, X)
     return MMI.table(X̃, names=node_labels, prototype=X)
 end
 
-
 metadata_pkg.(
     (SelfOrganizingMap,),
     name="SelfOrganizingMaps",
@@ -89,11 +88,8 @@ metadata_pkg.(
 
 metadata_model(
     SelfOrganizingMap,
-    human_name = "Self Organizing Map",
     input = MMI.Table(Continuous),
-    #output = AbstractVector{Multiclass},
     output = MMI.Table(Continuous),
-    weights = false,
     path = "$(PKG).SelfOrganizingMap"
 )
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+MLJTestIntegration = "697918b4-fdc1-4f9e-8ff9-929724cee270"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Distances
 using MLJBase
 using StableRNGs  # should add this for later
 using DataFrames
+using MLJTestIntegration
 
 stable_rng() = StableRNGs.StableRNG(1234)
 
@@ -79,7 +80,22 @@ end
     @test size(X̃[1],1) == 50
 end
 
-
+@testset "MLJ interface" begin
+    r = [1.0, 0.0, 0.0]
+    g = [0.0, 1.0, 0.0]
+    b = [0.0, 0.0, 1.0]
+    X = (; r, g, b) # a column table
+    models = [SelfOrganizingMap,]
+    failures, summary = MLJTestIntegration.test(
+        models,
+        X;
+        mod=@__MODULE__,
+        verbosity=0, # set to 2 for maximum information
+        throw=false, # set to true to debug
+    )
+    @test isempty(failures)
+    @test summary[1].operations == "transform"
+end
 
 function SOMtoRGB(som::SOM)
     SOM_pretty = [RGB(som.W[1,i], som.W[2,i], som.W[3,i]) for i∈1:size(som.W, 2)]


### PR DESCRIPTION
In support of #8.

The interface looks very good. Only caught one mistake with a missing type annotation, corrected in this PR. 

This PR also adds a generic MLJ interface test, requiring that I add MLJTestIntegration to the test dependencies. You could keep this, although this adds MLJ (rather than MLJBase) as a test dependency, and is still a little experimental. 

I've added some further comments at #8