### PR TITLE
Use MLJTestInterface.jl instead of MLJTestIntegration.jl in tests to lower test dependency burden

### DIFF
--- a/src/SelfOrganizingMaps.jl
+++ b/src/SelfOrganizingMaps.jl
@@ -135,7 +135,7 @@ Train the machine with `fit!(mach, rows=...)`.
 - `Nepochs=1` Number of times to repeat training on the shuffled dataset.
 
 # Operations
-- `transform(mach, X)`: returns the coordinates of the winning SOM node for each instance of `X`. For SOM of grid_type `:rectangular` and `:hexagonal`, these are cartesian coordinates. For grid_type `:spherical`, these are the latitude and longitude in radians.
+- `transform(mach, Xnew)`: returns the coordinates of the winning SOM node for each instance of `Xnew`. For SOM of grid_type `:rectangular` and `:hexagonal`, these are cartesian coordinates. For grid_type `:spherical`, these are the latitude and longitude in radians.
 
 # Fitted parameters
 The fields of `fitted_params(mach)` are:
@@ -147,7 +147,7 @@ The fields of `fitted_params(mach)` are:
 
 # Report
 The fields of `report(mach)` are:
-- `classes`: the index of the winning node for each instance in X interpreted as a class label
+- `classes`: the index of the winning node for each instance of the training data X interpreted as a class label
 
 # Examples
 ```

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,5 +2,6 @@
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJTestIntegration = "697918b4-fdc1-4f9e-8ff9-929724cee270"
+MLJTestInterface = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using Distances
 using MLJBase
 using StableRNGs  # should add this for later
-using MLJTestIntegration
+using MLJTestInterface
 
 stable_rng() = StableRNGs.StableRNG(1234)
 
@@ -96,7 +96,7 @@ end
     b = [0.0, 0.0, 1.0]
     X = (; r, g, b) # a column table
     models = [SelfOrganizingMap,]
-    failures, summary = MLJTestIntegration.test(
+    failures, summary = MLJTestInterface.test(
         models,
         X;
         mod=@__MODULE__,


### PR DESCRIPTION
Also adds a minor doc fix.